### PR TITLE
Fix error during serialization of the extent

### DIFF
--- a/quadfeather/tiler.py
+++ b/quadfeather/tiler.py
@@ -366,7 +366,7 @@ class Tile():
         """
         self.total_points = 0
         metadata = {
-            "extent": json.dumps(self.extent),
+            "extent": json.dumps({k : [float(f) for f in v] for k, v in self.extent.items()}),
         }
 
         if self._children is None:


### PR DESCRIPTION
During serialization of the extent, the JSON module expects Python floats instead of `numpy.float32` and was failing with error
`TypeError: Object of type float32 is not JSON serializable`.