### PR TITLE
Delete the temp repo, if it exists (does nothing otherwise)

### DIFF
--- a/quadfeather/tiler.py
+++ b/quadfeather/tiler.py
@@ -150,6 +150,7 @@ def rewrite_in_arrow_format(files, schema_safe : pa.Schema,
         "y": [float("inf"), -float("inf")],
     }
     output_dir = files[0].parent / "_deepscatter_tmp"
+    shutil.rmtree(output_dir) # in case it exists already from a previous tiling
     output_dir.mkdir()
     if "z" in schema.keys():
         extent["z"] = [float("inf"), -float("inf")]


### PR DESCRIPTION
I frequently ran into tiling errors on line 154 because it was trying to create a temp folder that already existed.

It's also possible that there's a more upstream error to be fixed: maybe we're just forgetting to delete the temp folder before the tiling function returns (ie it should be deleted even during a thrown error)?