### PR TITLE
update typehint to use typing.List

### DIFF
--- a/quadfeather/ingester.py
+++ b/quadfeather/ingester.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import DefaultDict, Dict, List, Tuple, Set, Optional
 
 class Ingester:
-  def __init__(self, files : list[Path], batch_size : int = 1024 * 1024 * 1024, columns = None, destructive = False):
+  def __init__(self, files : List[Path], batch_size : int = 1024 * 1024 * 1024, columns = None, destructive = False):
     # Allow iteration over a st
     # queue_size: maximum bytes in an insert chunk.
     self.files = files


### PR DESCRIPTION
Running quadfeather with older Python versions throws the following stack trace:

```python
Traceback (most recent call last):
  File "/home/richard/miniconda3/envs/seeweed/bin/quadfeather", line 5, in <module>
    from quadfeather.tiler import main
  File "/home/richard/miniconda3/envs/seeweed/lib/python3.8/site-packages/quadfeather/__init__.py", line 1, in <module>
    from .tiler import Tile, main
  File "/home/richard/miniconda3/envs/seeweed/lib/python3.8/site-packages/quadfeather/tiler.py", line 16, in <module>
    from .ingester import get_ingester
  File "/home/richard/miniconda3/envs/seeweed/lib/python3.8/site-packages/quadfeather/ingester.py", line 6, in <module>
    class Ingester:
  File "/home/richard/miniconda3/envs/seeweed/lib/python3.8/site-packages/quadfeather/ingester.py", line 7, in Ingester
    def __init__(self, files : list[Path], batch_size : int = 1024 * 1024 * 1024, columns = None, destructive = False):
TypeError: 'type' object is not subscriptable
```

This PR solves this by replacing `list[Path]` with `typing.List[Path]`